### PR TITLE
Adiciona codificação de UTF-8 na conversão byte a string

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleTranslationFileCreator.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleTranslationFileCreator.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class ResourceBundleTranslationFileCreator implements TranslationFileCreator {
@@ -90,7 +91,7 @@ public class ResourceBundleTranslationFileCreator implements TranslationFileCrea
                               ".properties",
                               tempDir.toFile());
                       tempLocalFileStream = new FileOutputStream(tempLocaleFile);
-                      tempLocalFileStream.write(localeStringEntry.getValue().getBytes());
+                      tempLocalFileStream.write(localeStringEntry.getValue().getBytes(StandardCharsets.UTF_8));  // Specifying UTF-8 encoding
                       tempLocalFileStream.close();
                       return tempLocaleFile;
                     } catch (IOException e) {
@@ -139,7 +140,7 @@ public class ResourceBundleTranslationFileCreator implements TranslationFileCrea
     var translations = translationService.getTranslations(locale);
     var contentString = singleBundleContentString(translations);
 
-    return contentString.getBytes();
+    return contentString.getBytes(StandardCharsets.UTF_8);  // Specifying UTF-8 encoding
   }
 
   private String singleBundleContentString(Collection<Translation> translations) {


### PR DESCRIPTION
- ### Descrição

Para garantir a conformidade com práticas recomendadas de internacionalização, foi realizada uma modificação na classe ResourceBundleTranslationFileCreator. Essa alteração se concentrou nos métodos createGlobalTranslationFile e createLocaleTranslationFile, onde a conversão de strings para bytes foi adaptada para especificar explicitamente a codificação UTF-8. Ao adicionar StandardCharsets.UTF_8, asseguramos que a conversão entre bytes e strings seja realizada de maneira consistente e portável em diferentes plataformas, evitando problemas relacionados à internacionalização. Essa mudança contribui para a robustez e confiabilidade do código, garantindo seu bom funcionamento em ambientes multilíngues.