### PR TITLE
refatoração do código para não depender do encoding padrão do sistema…

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleParser.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleParser.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Locale;
@@ -37,12 +38,13 @@ public class ResourceBundleParser implements TranslationFileParser {
   private static final String SEPARATOR = "=";
   private static final String COMMENT_START = "#";
 
-  @Override
   public Collection<Translation> parse(
       @NotNull final InputStream fileStream, @NotNull final Locale targetLocale) {
     var translations = new LinkedList<Translation>();
 
-    try (var fileReader = new BufferedReader(new InputStreamReader(fileStream))) {
+    try (var fileReader =
+        new BufferedReader(
+            new InputStreamReader(fileStream, StandardCharsets.UTF_8))) { // Use UTF-8
       while (fileReader.ready()) {
         var currentLine = fileReader.readLine();
         if (!currentLine.isBlank() && !currentLine.startsWith(COMMENT_START)) {
@@ -50,7 +52,7 @@ public class ResourceBundleParser implements TranslationFileParser {
         }
       }
     } catch (IOException e) {
-      throw new TranslationFileException(e);
+      throw new TranslationFileException("Error while parsing translation file", e);
     }
 
     return translations;

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/ResourcerBundleParserTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/ResourcerBundleParserTest.java
@@ -1,0 +1,78 @@
+package de.frachtwerk.essencium.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.frachtwerk.essencium.backend.model.Translation;
+import de.frachtwerk.essencium.backend.model.exception.TranslationFileException;
+import de.frachtwerk.essencium.backend.service.translation.ResourceBundleParser;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+class ResourceBundleParserTest {
+
+  private final ResourceBundleParser parser = new ResourceBundleParser();
+
+  @Test
+  void parseInvalidLine() {
+    // Simulando uma linha inválida no arquivo de recursos
+    String invalidLine = "key_without_value";
+
+    // Criando um InputStream com a linha inválida
+    InputStream inputStream =
+        new ByteArrayInputStream(invalidLine.getBytes(StandardCharsets.UTF_8));
+
+    // Chamando o método parse com o InputStream e uma Locale válida
+    // O teste deve lançar uma TranslationFileException devido à linha inválida
+    assertThrows(TranslationFileException.class, () -> parser.parse(inputStream, Locale.ENGLISH));
+  }
+
+  @Test
+  void parseInvalidEncoding() {
+    // Simulando uma linha com caracteres inválidos para o UTF-8
+    String invalidLine =
+        "Inválido: \uD83D\uDE00"; // Emojis, que podem causar problemas de decodificação
+
+    // Criando um InputStream com a linha inválida
+    InputStream inputStream =
+        new ByteArrayInputStream(invalidLine.getBytes(StandardCharsets.ISO_8859_1));
+
+    // Chamando o método parse com o InputStream e uma Locale válida
+    // O teste deve lançar uma TranslationFileException devido à falha na decodificação
+    assertThrows(TranslationFileException.class, () -> parser.parse(inputStream, Locale.ENGLISH));
+  }
+
+  @Test
+  void parseEmptyFile() {
+    // Simulando um arquivo de recursos vazio
+    String emptyFileContent = "";
+
+    // Criando um InputStream com o conteúdo do arquivo vazio
+    InputStream inputStream =
+        new ByteArrayInputStream(emptyFileContent.getBytes(StandardCharsets.UTF_8));
+
+    // Chamando o método parse com o InputStream e uma Locale válida
+    Collection<Translation> translations = parser.parse(inputStream, Locale.ENGLISH);
+
+    // Verificando se a coleção de traduções está vazia
+    assertEquals(Collections.emptyList(), translations);
+  }
+
+  @Test
+  void parseInvalidLineFormat() {
+    // Simulando uma linha com formato inválido no arquivo de recursos
+    String invalidLine = "chave_sem_valor";
+
+    // Criando um InputStream com a linha com formato inválido
+    InputStream inputStream =
+        new ByteArrayInputStream(invalidLine.getBytes(StandardCharsets.UTF_8));
+
+    // Chamando o método parse com o InputStream e uma Locale válida
+    // O teste deve lançar uma TranslationFileException devido ao formato inválido da linha
+    assertThrows(TranslationFileException.class, () -> parser.parse(inputStream, Locale.ENGLISH));
+  }
+}


### PR DESCRIPTION
O código estava fazendo uma conversão entre bytes e strings sem especificar explicitamente um conjunto de caracteres (charset), o que pode levar a comportamentos inesperados, pois o comportamento padrão pode variar entre plataformas.
Além da refatoração para corrigir esse problema, foi criado testes para garantir a consistência da classe.