### PR TITLE
Corrige problema de codificação padrão apontado pelo SpotBugs - OutputStreamWriter

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/XliffTranslationFileGenerator.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/XliffTranslationFileGenerator.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class XliffTranslationFileGenerator implements TranslationFileCreator {
@@ -63,7 +64,7 @@ public class XliffTranslationFileGenerator implements TranslationFileCreator {
     var byteArrayOutputStream = new ByteArrayOutputStream();
 
     try (byteArrayOutputStream;
-        var streamWriter = new OutputStreamWriter(byteArrayOutputStream);
+        var streamWriter = new OutputStreamWriter(byteArrayOutputStream, StandardCharsets.UTF_8);
         var writer = new XLIFFWriter()) {
       writer.create(streamWriter, DEFAULT_SOURCE_LOCALE.getLanguage());
       locales.forEach(
@@ -91,7 +92,7 @@ public class XliffTranslationFileGenerator implements TranslationFileCreator {
     final var byteArrayOutputStream = new ByteArrayOutputStream();
 
     try (byteArrayOutputStream;
-        final var streamWriter = new OutputStreamWriter(byteArrayOutputStream);
+        final var streamWriter = new OutputStreamWriter(byteArrayOutputStream, StandardCharsets.UTF_8);
         final var writer = new XLIFFWriter()) {
       writer.create(streamWriter, DEFAULT_SOURCE_LOCALE.getLanguage(), locale.getLanguage());
       writer.writeStartFile(new StartFileData(locale.getLanguage()));


### PR DESCRIPTION
Este pull request corrige um problema identificado pelo SpotBugs relacionado à codificação padrão ao criar OutputStreamWriter na classe XliffTranslationFileGenerator. A correção envolveu a especificação explícita da codificação UTF-8 ao criar os OutputStreamWriter nos métodos createGlobalTranslationFile e createLocaleTranslationFile. Essa alteração garante consistência na codificação e evita comportamentos inesperados em diferentes plataformas. Todos os testes foram executados e passaram com sucesso.