### PR TITLE
Corrige problema de codificação padrão apontado pelo SpotBugs - OutputStreamWriter 

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/XliffTranslationFileGenerator.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/XliffTranslationFileGenerator.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class XliffTranslationFileGenerator implements TranslationFileCreator {
@@ -63,7 +64,7 @@ public class XliffTranslationFileGenerator implements TranslationFileCreator {
     var byteArrayOutputStream = new ByteArrayOutputStream();
 
     try (byteArrayOutputStream;
-        var streamWriter = new OutputStreamWriter(byteArrayOutputStream);
+        var streamWriter = new OutputStreamWriter(byteArrayOutputStream, StandardCharsets.UTF_8);
         var writer = new XLIFFWriter()) {
       writer.create(streamWriter, DEFAULT_SOURCE_LOCALE.getLanguage());
       locales.forEach(
@@ -91,7 +92,7 @@ public class XliffTranslationFileGenerator implements TranslationFileCreator {
     final var byteArrayOutputStream = new ByteArrayOutputStream();
 
     try (byteArrayOutputStream;
-        final var streamWriter = new OutputStreamWriter(byteArrayOutputStream);
+        final var streamWriter = new OutputStreamWriter(byteArrayOutputStream, StandardCharsets.UTF_8);
         final var writer = new XLIFFWriter()) {
       writer.create(streamWriter, DEFAULT_SOURCE_LOCALE.getLanguage(), locale.getLanguage());
       writer.writeStartFile(new StartFileData(locale.getLanguage()));

--- a/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/XliffTranslationFileGeneratorTest.java
+++ b/essencium-backend/src/test/java/de/frachtwerk/essencium/backend/service/XliffTranslationFileGeneratorTest.java
@@ -1,0 +1,46 @@
+package de.frachtwerk.essencium.backend.service;
+
+import de.frachtwerk.essencium.backend.service.translation.TranslationService;
+import de.frachtwerk.essencium.backend.service.translation.XliffTranslationFileGenerator;
+import de.frachtwerk.essencium.backend.repository.TranslationRepository;
+import org.junit.jupiter.api.Test;
+import java.util.Locale;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class XliffTranslationFileGeneratorTest {
+
+    private final TranslationRepository mockRepository = mock(TranslationRepository.class);
+    private final TranslationService translationService = new TranslationService(mockRepository);
+    private final XliffTranslationFileGenerator generator = new XliffTranslationFileGenerator(translationService);
+
+    @Test
+    void createLocaleTranslationFile() {
+        Locale locale = Locale.ENGLISH;
+        byte[] translationFile = generator.createLocaleTranslationFile(locale, true);
+
+        assertNotNull(translationFile);
+        assertTrue(translationFile.length > 0);
+
+    }
+
+    @Test
+    void createLocaleTranslationFile_NoCache() {
+        Locale locale = Locale.GERMAN;
+        byte[] translationFile = generator.createLocaleTranslationFile(locale, false);
+
+        assertNotNull(translationFile);
+        assertTrue(translationFile.length > 0);
+    }
+
+    @Test
+    void createLocaleTranslationFile_WithCache() {
+        Locale locale = Locale.FRENCH;
+        byte[] translationFile = generator.createLocaleTranslationFile(locale, true);
+
+        assertNotNull(translationFile);
+        assertTrue(translationFile.length > 0);
+    }
+
+}


### PR DESCRIPTION
Este pull request corrige um problema identificado pelo SpotBugs relacionado à codificação padrão ao criar OutputStreamWriter na classe XliffTranslationFileGenerator. A correção envolveu a especificação explícita da codificação UTF-8 ao criar os OutputStreamWriter nos métodos createGlobalTranslationFile e createLocaleTranslationFile. Essa alteração garante consistência na codificação e evita comportamentos inesperados em diferentes plataformas. Todos os testes foram executados e passaram com sucesso.

Uma classe de testes iniciais foi adicionado (XliffTranslationFileGeneratorTest.java).