### PR TITLE
Adiciona verificação nula ao ler linhas no ResourceBundleParser

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleParser.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/translation/ResourceBundleParser.java
@@ -45,8 +45,8 @@ public class ResourceBundleParser implements TranslationFileParser {
     try (var fileReader =
         new BufferedReader(
             new InputStreamReader(fileStream, StandardCharsets.UTF_8))) { // Use UTF-8
-      while (fileReader.ready()) {
-        var currentLine = fileReader.readLine();
+      String currentLine;
+      while ((currentLine = fileReader.readLine()) != null) {
         if (!currentLine.isBlank() && !currentLine.startsWith(COMMENT_START)) {
           translations.add(parseSingleLine(currentLine, targetLocale));
         }


### PR DESCRIPTION
Este pull request adiciona uma verificação nula ao ler linhas no método parse da classe ResourceBundleParser. Isso resolve o problema apontado pelo SpotBugs, onde a dereferenciação do resultado de readLine() sem verificação nula poderia causar uma NullPointerException. A mudança garante que o código seja mais robusto ao lidar com arquivos de tradução e evita exceções não tratadas.
