### PR TITLE
Refatoração: Evitar capturar NullPointerException no método isAccessTokenValid

### DIFF
--- a/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/JwtTokenService.java
+++ b/essencium-backend/src/main/java/de/frachtwerk/essencium/backend/service/JwtTokenService.java
@@ -233,10 +233,10 @@ public class JwtTokenService implements Clock {
   public boolean isAccessTokenValid(String refresh, String access) {
     SessionToken refreshToken = getRequestingToken(refresh);
     SessionToken accessToken = getRequestingToken(access);
-    try {
-      return Objects.equals(refreshToken, accessToken.getParentToken());
-    } catch (NullPointerException e) {
-      return false;
+    if (refreshToken == null || accessToken == null) {
+      return false; // no exceptions
     }
+
+    return Objects.equals(refreshToken, accessToken.getParentToken());
   }
 }


### PR DESCRIPTION
No método isAccessTokenValid da classe JwtTokenService, foi removida a captura de exceção NullPointerException que era usada para verificar se os objetos refreshToken e accessToken eram nulos. Em vez disso, agora há uma verificação direta da nulidade desses objetos. Essa abordagem simplifica o código e melhora sua legibilidade, tornando mais claro o fluxo de controle. Essas mudanças resultam em um código mais limpo, robusto e fácil de entender, alinhado com as boas práticas de programação. Isso facilita a manutenção futura do código e aumenta sua qualidade geral.